### PR TITLE
Removed particle weight resetting in the odom callback

### DIFF
--- a/amcl/src/amcl/sensors/amcl_odom.cpp
+++ b/amcl/src/amcl/sensors/amcl_odom.cpp
@@ -199,12 +199,6 @@ bool AMCLOdom::UpdateAction(pf_t *pf, AMCLSensorData *data)
     double std_rot_2 = this->alpha1*delta_rot2_noise*delta_rot2_noise +
       this->alpha2*delta_trans*delta_trans;
 
-    if(0){
-      fprintf(stdout, "Delta : %f, %f, %f Std R1 : %.4f T : %.4f R2: %.4f\n", 
-	      delta_rot1, delta_trans, delta_rot2, std_rot_1, std_trans, 
-	      std_rot_2);
-    }
-
     for (int i = 0; i < set->sample_count; i++)
     {
       pf_sample_t* sample = set->samples + i;


### PR DESCRIPTION
Removed particle weights being reset by the motion update.
