### PR TITLE
added option to score the heading of the rotate in place trajectories - ...

### DIFF
--- a/base_local_planner/cfg/BaseLocalPlanner.cfg
+++ b/base_local_planner/cfg/BaseLocalPlanner.cfg
@@ -50,6 +50,8 @@ gen.add("escape_vel", double_t, 0, "The velocity to use while backing up", -0.1,
 gen.add("dwa", bool_t, 0, "Set this to true to use the Dynamic Window Approach, false to use acceleration limits", False)
 
 gen.add("heading_scoring", bool_t, 0, "Set this to true to use the Dynamic Window Approach, false to use acceleration limits", False)
+gen.add("heading_scoring_on_rotate", bool_t, 0, "Set this to score heading when rotating in place", False)
+gen.add("heading_scale", double_t, 0, "The weight for the heading_difference for a trajectory (used when heading scoring/heading scoring on rotate is enabled", 0.001, 0, 5)
 gen.add("heading_scoring_timestep", double_t, 0, "How far to look ahead in time when we score heading based trajectories", 0.1, 0, 1)
 
 gen.add("simple_attractor", bool_t, 0, "Set this to true to allow simple attraction to a goal point instead of intelligent cost propagation", False)

--- a/base_local_planner/include/base_local_planner/trajectory_planner.h
+++ b/base_local_planner/include/base_local_planner/trajectory_planner.h
@@ -100,6 +100,8 @@ namespace base_local_planner {
        * @param backup_vel The velocity to use while backing up
        * @param dwa Set this to true to use the Dynamic Window Approach, false to use acceleration limits
        * @param heading_scoring Set this to true to score trajectories based on the robot's heading after 1 timestep
+       * @param heading_scoring_on_rotate Set this to true to score rotate-in-place trajectories
+       * @param heading_scale - gain for heading difference
        * @param heading_scoring_timestep How far to look ahead in time when we score heading based trajectories
        * @param meter_scoring adapt parameters to costmap resolution
        * @param simple_attractor Set this to true to allow simple attraction to a goal point instead of intelligent cost propagation
@@ -120,6 +122,7 @@ namespace base_local_planner {
           double max_vel_th = 1.0, double min_vel_th = -1.0, double min_in_place_vel_th = 0.4,
           double backup_vel = -0.1,
           bool dwa = false, bool heading_scoring = false, double heading_scoring_timestep = 0.1,
+          bool heading_scoring_on_rotate=false, double heading_scale=0.001, 
           bool meter_scoring = true,
           bool simple_attractor = false,
           std::vector<double> y_vels = std::vector<double>(0),
@@ -337,6 +340,9 @@ namespace base_local_planner {
       bool dwa_;  ///< @brief Should we use the dynamic window approach?
       bool heading_scoring_; ///< @brief Should we score based on the rollout approach or the heading approach
       double heading_scoring_timestep_; ///< @brief How far to look ahead in time when we score a heading
+
+      bool heading_scoring_on_rotate_;
+      double heading_scale_;
       bool simple_attractor_;  ///< @brief Enables simple attraction to a goal point
 
       std::vector<double> y_vels_; ///< @brief Y velocities to explore
@@ -410,7 +416,6 @@ namespace base_local_planner {
       double lineCost(int x0, int x1, int y0, int y1);
       double pointCost(int x, int y);
       double headingDiff(int cell_x, int cell_y, double x, double y, double heading);
-      double headingDiffOriginal(int cell_x, int cell_y, double x, double y, double heading);
   };
 };
 

--- a/base_local_planner/src/trajectory_planner_ros.cpp
+++ b/base_local_planner/src/trajectory_planner_ros.cpp
@@ -98,8 +98,8 @@ namespace base_local_planner {
       trans_stopped_velocity_ = 1e-2;
       double sim_time, sim_granularity, angular_sim_granularity;
       int vx_samples, vtheta_samples;
-      double pdist_scale, gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta;
-      bool holonomic_robot, dwa, simple_attractor, heading_scoring;
+      double pdist_scale, gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta, heading_scale;
+      bool holonomic_robot, dwa, simple_attractor, heading_scoring, heading_scoring_on_rotate;
       double heading_scoring_timestep;
       double max_vel_x, min_vel_x;
       double backup_vel;
@@ -170,6 +170,7 @@ namespace base_local_planner {
       private_nh.param("vtheta_samples", vtheta_samples, 20);
 
       private_nh.param("path_distance_bias", pdist_scale, 0.6);
+      private_nh.param("heading_scale", heading_scale, 0.001);
       private_nh.param("goal_distance_bias", gdist_scale, 0.8);
       private_nh.param("occdist_scale", occdist_scale, 0.01);
 
@@ -219,6 +220,7 @@ namespace base_local_planner {
       private_nh.param("world_model", world_model_type, std::string("costmap"));
       private_nh.param("dwa", dwa, true);
       private_nh.param("heading_scoring", heading_scoring, false);
+      private_nh.param("heading_scoring_on_rotate", heading_scoring_on_rotate, false);
       private_nh.param("heading_scoring_timestep", heading_scoring_timestep, 0.8);
 
       simple_attractor = false;
@@ -237,10 +239,13 @@ namespace base_local_planner {
       footprint_spec_ = costmap_ros_->getRobotFootprint();
 
       tc_ = new TrajectoryPlanner(*world_model_, *costmap_, footprint_spec_,
-          acc_lim_x_, acc_lim_y_, acc_lim_theta_, sim_time, sim_granularity, vx_samples, vtheta_samples, pdist_scale,
-          gdist_scale, occdist_scale, heading_lookahead, oscillation_reset_dist, escape_reset_dist, escape_reset_theta, holonomic_robot,
-          max_vel_x, min_vel_x, max_vel_th_, min_vel_th_, min_in_place_vel_th_, backup_vel,
-          dwa, heading_scoring, heading_scoring_timestep, meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity);
+                                  acc_lim_x_, acc_lim_y_, acc_lim_theta_, sim_time, sim_granularity, 
+                                  vx_samples, vtheta_samples, pdist_scale, gdist_scale, 
+                                  occdist_scale, heading_lookahead, oscillation_reset_dist, 
+                                  escape_reset_dist, escape_reset_theta, holonomic_robot,
+                                  max_vel_x, min_vel_x, max_vel_th_, min_vel_th_, min_in_place_vel_th_, backup_vel,
+                                  dwa, heading_scoring, heading_scoring_timestep, heading_scoring_on_rotate, heading_scale, 
+                                  meter_scoring, simple_attractor, y_vels, stop_time_buffer, sim_period_, angular_sim_granularity);
       
       map_viz_.initialize(name, global_frame_, boost::bind(&TrajectoryPlanner::getCellCosts, tc_, _1, _2, _3, _4, _5, _6));
       initialized_ = true;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -753,7 +753,7 @@ namespace move_base {
             return;
           }
 
-	  ROS_INFO("Action server received new goal\n");
+	  ROS_INFO("Action server received new goal");
 
           goal = goalToGlobalFrame(new_goal.target_pose);
 


### PR DESCRIPTION
Added option to enable rotate in place trajectories to be scored for the heading difference. 

Currently it scores all rotate-in-place trajectories the same - which can lead to the wrong rotate-velocity being picked (which would be noticeable at the start) 

Enable with  heading_scoring_on_rotate

Set the heading_scale to set the weight - suggest setting a small value - so that it doesn't result in weird weighting behavior (suggested 0.001)
