### PR TITLE
Fix assertion in amcl

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1549,7 +1549,7 @@ AmclNode::handleInitialHypothesisSetMessage(const HypothesisSet &msg)
 {
     boost::recursive_mutex::scoped_lock prl(configuration_mutex_);
     assert(msg.hypotheses.size() != 0);
-    assert(max_beams_/msg.hypotheses.size() > 0);
+    assert(max_particles_/msg.hypotheses.size() > 0);
     if(msg.header.frame_id == "")
     {
         // This should be removed at some point


### PR DESCRIPTION
 max_particles_ is the param used to initialize the pf.  Other param doesnt make sense.
