### PR TITLE
Kaijen/nav 8/amcl motion model

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -24,8 +24,8 @@ gen.add("recovery_alpha_slow", double_t, 0, "Exponential decay rate for the slow
 gen.add("recovery_alpha_fast", double_t, 0, "Exponential decay rate for the fast average weight filter, used in deciding when to recover by adding random poses. A good value might be 0.1.", 0, 0, 1)
 
 gen.add("do_beamskip", bool_t, 0, "When true skips laser scans when a scan doesnt work for a majority of particles", False)
-gen.add("beam_skip_distance", double_t, 0, "Distance from a valid map point before scan is considered invalid", 0, 2, 0.5)
-gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scans are valid to consider as valid scan", 0, 1, 0.3)
+gen.add("beam_skip_distance", double_t, 0, "Distance from a valid map point before scan is considered invalid", 0.5, 0, 2)
+gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scans are valid to consider as valid scan", 0.3, 0, 1)
 
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
@@ -50,8 +50,9 @@ gen.add("laser_lambda_short", double_t, 0, "Exponential decay parameter for z_sh
 gen.add("laser_likelihood_max_dist", double_t, 0, "Maximum distance to do obstacle inflation on map, for use in likelihood_field model.", 2, 0, 20)
 
 lmt = gen.enum([gen.const("beam_const", str_t, "beam", "Use beam laser model"), 
-                gen.const("likelihood_field_prob_const", str_t, "likelihood_field", "Use likelihood_field_prob laser model"), 
-                gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model")], "Laser Models")
+                gen.const("likelihood_field_prob_const", str_t, "likelihood_field_prob", "Use likelihood_field_prob laser model"), 
+                gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model")], 
+                "Laser Models")
 gen.add("laser_model_type", str_t, 0, "Which model to use, either beam, likelihood_field or likelihood_field_prob.", "likelihood_field", edit_method=lmt)
 
 # Odometry Model Parameters
@@ -68,7 +69,7 @@ gen.add("odom_alpha3", double_t, 0, "Specifies the expected noise in odometry's 
 gen.add("odom_alpha4", double_t, 0, "Specifies the expected noise in odometry's translation  estimate from the rotational component of the robot's motion.", .2, 0, 10)
 gen.add("odom_alpha5", double_t, 0, "Translation-related noise parameter (only used if model is omni).", .2, 0, 10)
 
-gen.add("stuck_prob", double_t, 0, "Fraction of particles used to model a stuck robot in motion update", 0.0, 1.0, 0.0)
+gen.add("stuck_prob", double_t, 0, "Fraction of particles used to model a stuck robot in motion update", 0.0, 0.0, 1.0)
 
 gen.add("odom_frame_id", str_t, 0, "Which frame to use for odometry.", "odom")
 gen.add("base_frame_id", str_t, 0, "Which frame to use for the robot base.", "base_link")

--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -49,7 +49,9 @@ gen.add("laser_sigma_hit", double_t, 0, "Standard deviation for Gaussian model u
 gen.add("laser_lambda_short", double_t, 0, "Exponential decay parameter for z_short part of model.", .1, 0, 10)
 gen.add("laser_likelihood_max_dist", double_t, 0, "Maximum distance to do obstacle inflation on map, for use in likelihood_field model.", 2, 0, 20)
 
-lmt = gen.enum([gen.const("beam_const", str_t, "beam", "Use beam laser model"), gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model")], "Laser Models")
+lmt = gen.enum([gen.const("beam_const", str_t, "beam", "Use beam laser model"), 
+                gen.const("likelihood_field_prob_const", str_t, "likelihood_field", "Use likelihood_field_prob laser model"), 
+                gen.const("likelihood_field_const", str_t, "likelihood_field", "Use likelihood_field laser model")], "Laser Models")
 gen.add("laser_model_type", str_t, 0, "Which model to use, either beam, likelihood_field or likelihood_field_prob.", "likelihood_field", edit_method=lmt)
 
 # Odometry Model Parameters
@@ -65,6 +67,8 @@ gen.add("odom_alpha2", double_t, 0, "Specifies the expected noise in odometry's 
 gen.add("odom_alpha3", double_t, 0, "Specifies the expected noise in odometry's translation estimate from the translational component of the robot's motion.", .2, 0, 10)
 gen.add("odom_alpha4", double_t, 0, "Specifies the expected noise in odometry's translation  estimate from the rotational component of the robot's motion.", .2, 0, 10)
 gen.add("odom_alpha5", double_t, 0, "Translation-related noise parameter (only used if model is omni).", .2, 0, 10)
+
+gen.add("stuck_prob", double_t, 0, "Fraction of particles used to model a stuck robot in motion update", 0.0, 1.0, 0.0)
 
 gen.add("odom_frame_id", str_t, 0, "Which frame to use for odometry.", "odom")
 gen.add("base_frame_id", str_t, 0, "Which frame to use for the robot base.", "base_link")

--- a/amcl/include/amcl/sensors/amcl_odom.h
+++ b/amcl/include/amcl/sensors/amcl_odom.h
@@ -76,7 +76,8 @@ class AMCLOdom : public AMCLSensor
                          double alpha2,
                          double alpha3,
                          double alpha4,
-                         double alpha5 = 0 );
+                         double alpha5 = 0,
+                         double stuck_prob = 0 );
 
   // Update the filter based on the action model.  Returns true if the filter
   // has been updated.
@@ -90,6 +91,10 @@ class AMCLOdom : public AMCLSensor
 
   // Drift parameters
   private: double alpha1, alpha2, alpha3, alpha4, alpha5;
+
+  // Fraction of particles to leave where they are instead of moving according 
+  // to the odom motion model (in case the robot is actually stuck and the wheels are slipping)
+  private: double stuck_prob;
 };
 
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -268,6 +268,7 @@ class AmclNode
 
     int max_beams_, min_particles_, max_particles_;
     double alpha1_, alpha2_, alpha3_, alpha4_, alpha5_;
+    double stuck_prob_;
     double alpha_slow_, alpha_fast_;
     double z_hit_, z_short_, z_max_, z_rand_, sigma_hit_, lambda_short_;
   //beam skip related params
@@ -374,6 +375,7 @@ AmclNode::AmclNode() :
   private_nh_.param("odom_alpha3", alpha3_, 0.2);
   private_nh_.param("odom_alpha4", alpha4_, 0.2);
   private_nh_.param("odom_alpha5", alpha5_, 0.2);
+  private_nh_.param("stuck_prob", stuck_prob_, 0.0);
   
   private_nh_.param("do_beamskip", do_beamskip_, false);
   private_nh_.param("beam_skip_distance", beam_skip_distance_, 0.5);
@@ -543,6 +545,7 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
   alpha3_ = config.odom_alpha3;
   alpha4_ = config.odom_alpha4;
   alpha5_ = config.odom_alpha5;
+  stuck_prob_ = config.stuck_prob;
 
   z_hit_ = config.laser_z_hit;
   z_short_ = config.laser_z_short;
@@ -612,7 +615,7 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
   delete odom_;
   odom_ = new AMCLOdom();
   ROS_ASSERT(odom_);
-  odom_->SetModel( odom_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_ );
+  odom_->SetModel( odom_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_, stuck_prob_ );
   // Laser
   delete laser_;
   laser_ = new AMCLLaser(max_beams_, map_);
@@ -817,7 +820,7 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
   delete odom_;
   odom_ = new AMCLOdom();
   ROS_ASSERT(odom_);
-  odom_->SetModel( odom_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_ );
+  odom_->SetModel( odom_model_type_, alpha1_, alpha2_, alpha3_, alpha4_, alpha5_, stuck_prob_ );
   // Laser
   delete laser_;
   laser_ = new AMCLLaser(max_beams_, map_);


### PR DESCRIPTION
Fixes NAV-8
#### What's going on in this code? How does it fix/implement the described functionality?

Adds a component to the amcl motion model that leaves behind some of the particles (modeling the case where the robot is actually stuck and the wheels are just slipping.  
#### Tested with:
- [x] Simulation
- [x] Robot - NAME_OF_ROBOT
#### Instructions for runnning:

``` bash
rosrun app_bringup gizmo -s
```

In simulation, drive the robot into the wall and watch the particles left behind, causing the robot's estimate of where it is to snap back upon resampling.  Set the stuck_prob to 0 to disable it, and give it a value of 0.05 or so to enable it.
#### Tester should verify this with:
- [ ] Simulation
