### PR TITLE
amcl_laser: penalize particles that end up in unknown areas of map

### DIFF
--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -27,6 +27,10 @@ gen.add("do_beamskip", bool_t, 0, "When true skips laser scans when a scan doesn
 gen.add("beam_skip_distance", double_t, 0, "Distance from a valid map point before scan is considered invalid", 0.5, 0, 2)
 gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scans are valid to consider as valid scan", 0.3, 0, 1)
 
+gen.add("penalize_unknown", bool_t, 0, "When true, penalize particles for being in unknown space", False)
+gen.add("unknown_radius", int_t, 0, "Radius around particle's pose to look for unknown pixels (where the area is pow(radius*2+1, 2))", 4, 0, 50)
+gen.add("unknown_threshold", double_t, 0, "When ratio of unknown pixels over area exceeds this, start penalizing particles for being in unknown space", 0.6, 0, 1)
+
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)
 gen.add("save_pose_rate", double_t, 0, "Maximum rate (Hz) at which to store the last estimated pose and covariance to the parameter server, in the variables ~initial_pose_* and ~initial_cov_*. This saved pose will be used on subsequent runs to initialize the filter. -1.0 to disable.", .5, 0, 10)

--- a/amcl/cfg/AMCL.cfg
+++ b/amcl/cfg/AMCL.cfg
@@ -30,6 +30,7 @@ gen.add("beam_skip_threshold", double_t, 0, "Ratio of samples for which the scan
 gen.add("penalize_unknown", bool_t, 0, "When true, penalize particles for being in unknown space", False)
 gen.add("unknown_radius", int_t, 0, "Radius around particle's pose to look for unknown pixels (where the area is pow(radius*2+1, 2))", 4, 0, 50)
 gen.add("unknown_threshold", double_t, 0, "When ratio of unknown pixels over area exceeds this, start penalizing particles for being in unknown space", 0.6, 0, 1)
+gen.add("unknown_min_penalty", double_t, 0, "Lowest weight allowed even if particle is being penalized for being in unknown space", 0.2, 0, 1)
 
 gen.add("tf_broadcast", bool_t, 0, "When true (the default), publish results via TF.  When false, do not.", True)
 gen.add("gui_publish_rate", double_t, 0, "Maximum rate (Hz) at which scans and paths are published for visualization, -1.0 to disable.", -1, -1, 100)

--- a/amcl/include/amcl/sensors/amcl_laser.h
+++ b/amcl/include/amcl/sensors/amcl_laser.h
@@ -85,7 +85,10 @@ class AMCLLaser : public AMCLSensor
 					   bool do_beamskip, 
 					   double beam_skip_distance, 
 					   double beam_skip_threshold, 
-					   double beam_skip_error_threshold);
+					   double beam_skip_error_threshold,
+					   bool penalize_unknown,
+					   int unknown_radius,
+					   double unknown_threshold);
 
   // Update the filter based on the sensor model.  Returns true if the
   // filter has been updated.
@@ -98,6 +101,9 @@ class AMCLLaser : public AMCLSensor
   // Determine the probability for the given pose
   private: static double BeamModel(AMCLLaserData *data, 
                                    pf_sample_set_t* set);
+
+  private: double unknownPenalty(const map_t *map, pf_vector_t pose);
+
   // Determine the probability for the given pose
   private: static double LikelihoodFieldModel(AMCLLaserData *data, 
                                               pf_sample_set_t* set);
@@ -121,6 +127,11 @@ class AMCLLaser : public AMCLSensor
   
   // Max beams to consider
   private: int max_beams;
+
+  // Penalize particles in unknown space parameters
+  private: bool penalize_unknown;
+  private: int unknown_radius;
+  private: double unknown_threshold;
 
   // Beam skipping parameters (used by LikelihoodFieldModelProb model)
   private: bool do_beamskip; 

--- a/amcl/include/amcl/sensors/amcl_laser.h
+++ b/amcl/include/amcl/sensors/amcl_laser.h
@@ -75,7 +75,10 @@ class AMCLLaser : public AMCLSensor
   public: void SetModelLikelihoodField(double z_hit,
                                        double z_rand,
                                        double sigma_hit,
-                                       double max_occ_dist);
+                                       double max_occ_dist,
+                                       bool penalize_unknown,
+                                       int unknown_radius,
+                                       double unknown_threshold);
 
   //a more probabilistically correct model - also with the option to do beam skipping
   public: void SetModelLikelihoodFieldProb(double z_hit,

--- a/amcl/include/amcl/sensors/amcl_laser.h
+++ b/amcl/include/amcl/sensors/amcl_laser.h
@@ -78,7 +78,8 @@ class AMCLLaser : public AMCLSensor
                                        double max_occ_dist,
                                        bool penalize_unknown,
                                        int unknown_radius,
-                                       double unknown_threshold);
+                                       double unknown_threshold,
+                                       double unknown_min_penalty);
 
   //a more probabilistically correct model - also with the option to do beam skipping
   public: void SetModelLikelihoodFieldProb(double z_hit,
@@ -91,7 +92,8 @@ class AMCLLaser : public AMCLSensor
 					   double beam_skip_error_threshold,
 					   bool penalize_unknown,
 					   int unknown_radius,
-					   double unknown_threshold);
+					   double unknown_threshold,
+					   double unknown_min_penalty);
 
   // Update the filter based on the sensor model.  Returns true if the
   // filter has been updated.
@@ -135,6 +137,7 @@ class AMCLLaser : public AMCLSensor
   private: bool penalize_unknown;
   private: int unknown_radius;
   private: double unknown_threshold;
+  private: double unknown_min_penalty;
 
   // Beam skipping parameters (used by LikelihoodFieldModelProb model)
   private: bool do_beamskip; 

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -100,7 +100,10 @@ AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
 				       bool do_beamskip,
 				       double beam_skip_distance,
 				       double beam_skip_threshold, 
-				       double beam_skip_error_threshold)
+				       double beam_skip_error_threshold,
+				       bool penalize_unknown,
+				       int unknown_radius,
+				       double unknown_threshold)
 {
   this->model_type = LASER_MODEL_LIKELIHOOD_FIELD_PROB;
   this->z_hit = z_hit;
@@ -110,6 +113,9 @@ AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
   this->beam_skip_distance = beam_skip_distance;
   this->beam_skip_threshold = beam_skip_threshold;
   this->beam_skip_error_threshold = beam_skip_error_threshold;
+  this->penalize_unknown = penalize_unknown;
+  this->unknown_radius = unknown_radius;
+  this->unknown_threshold = unknown_threshold;
   map_update_cspace(this->map, max_occ_dist);
 }
 
@@ -208,6 +214,53 @@ double AMCLLaser::BeamModel(AMCLLaserData *data, pf_sample_set_t* set)
   return(total_weight);
 }
 
+
+double frac_unknown_area(const map_t *map, pf_vector_t pose, int radius)
+{
+    int robot_mi, robot_mj, num_unknown;
+    int side = radius * 2 + 1;
+    int area = side * side;
+
+    robot_mi = MAP_GXWX(map, pose.v[0]);
+    robot_mj = MAP_GYWY(map, pose.v[1]);
+
+    // Check square around robot pose for unknown pixels, if we're on the edge
+    // of the map, count non-existent pixels also as unknowns.
+    num_unknown = 0;
+    for (int i = robot_mi - radius; i <= robot_mi + radius; i++)
+    {
+        for (int j = robot_mj - radius; j <= robot_mj + radius; j++)
+        {
+            if (MAP_VALID(map, i, j))
+            {
+                if (map->cells[MAP_INDEX(map, i, j)].occ_state == 0)
+                    num_unknown += 1;
+            }
+            else
+                num_unknown += 1;
+        }
+    }
+
+    return (double) num_unknown / (double) area;
+}
+
+
+double AMCLLaser::unknownPenalty(const map_t *map, pf_vector_t pose)
+{
+    double in_unknown_penalty = 1.0;
+
+    if (penalize_unknown)
+    {
+        double frac_unknown = frac_unknown_area(
+                map, pose, unknown_radius);
+        if (frac_unknown > unknown_threshold)
+            in_unknown_penalty = 1 - frac_unknown;
+    }
+
+    return in_unknown_penalty;
+}
+
+
 double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set)
 {
   AMCLLaser *self;
@@ -285,7 +338,6 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
       // TODO: outlier rejection for short readings
 
       //*******No outlier rejection (bad for changed maps) (Carmen localizer has outlier rejection) 
-
       assert(pz <= 1.0);
       assert(pz >= 0.0);
       //      p *= pz;
@@ -293,9 +345,9 @@ double AMCLLaser::LikelihoodFieldModel(AMCLLaserData *data, pf_sample_set_t* set
       // works well, though...
       p += pz*pz*pz;
     }
-    
-    sample->weight *= p;
 
+    double in_unknown_penalty =  self->unknownPenalty(self->map, sample->pose);
+    sample->weight *= p * in_unknown_penalty;
     total_weight += sample->weight;
   }
 
@@ -482,8 +534,8 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
         }
       }
 
-      sample->weight *= exp(log_p);
-
+      double in_unknown_penalty = self->unknownPenalty(self->map, sample->pose);
+      sample->weight *= exp(log_p) * in_unknown_penalty;
       total_weight += sample->weight;
     }
   }

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -82,12 +82,18 @@ void
 AMCLLaser::SetModelLikelihoodField(double z_hit,
                                    double z_rand,
                                    double sigma_hit,
-                                   double max_occ_dist)
+                                   double max_occ_dist,
+                                   bool penalize_unknown,
+                                   int unknown_radius,
+                                   double unknown_threshold)
 {
   this->model_type = LASER_MODEL_LIKELIHOOD_FIELD;
   this->z_hit = z_hit;
   this->z_rand = z_rand;
   this->sigma_hit = sigma_hit;
+  this->penalize_unknown = penalize_unknown;
+  this->unknown_radius = unknown_radius;
+  this->unknown_threshold = unknown_threshold;
 
   map_update_cspace(this->map, max_occ_dist);
 }
@@ -249,12 +255,14 @@ double AMCLLaser::unknownPenalty(const map_t *map, pf_vector_t pose)
 {
     double in_unknown_penalty = 1.0;
 
-    if (penalize_unknown)
+    double unknown_min_penalty = .2;
+    if (this->penalize_unknown)
     {
         double frac_unknown = frac_unknown_area(
-                map, pose, unknown_radius);
-        if (frac_unknown > unknown_threshold)
-            in_unknown_penalty = 1 - frac_unknown;
+                map, pose, this->unknown_radius);
+        if (frac_unknown > this->unknown_threshold)
+            in_unknown_penalty = fmax(
+                    1 - frac_unknown, unknown_min_penalty);
     }
 
     return in_unknown_penalty;

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -85,7 +85,8 @@ AMCLLaser::SetModelLikelihoodField(double z_hit,
                                    double max_occ_dist,
                                    bool penalize_unknown,
                                    int unknown_radius,
-                                   double unknown_threshold)
+                                   double unknown_threshold,
+                                   double unknown_min_penalty)
 {
   this->model_type = LASER_MODEL_LIKELIHOOD_FIELD;
   this->z_hit = z_hit;
@@ -94,6 +95,7 @@ AMCLLaser::SetModelLikelihoodField(double z_hit,
   this->penalize_unknown = penalize_unknown;
   this->unknown_radius = unknown_radius;
   this->unknown_threshold = unknown_threshold;
+  this->unknown_min_penalty = unknown_min_penalty;
 
   map_update_cspace(this->map, max_occ_dist);
 }
@@ -109,7 +111,8 @@ AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
 				       double beam_skip_error_threshold,
 				       bool penalize_unknown,
 				       int unknown_radius,
-				       double unknown_threshold)
+				       double unknown_threshold,
+                       double unknown_min_penalty)
 {
   this->model_type = LASER_MODEL_LIKELIHOOD_FIELD_PROB;
   this->z_hit = z_hit;
@@ -122,6 +125,7 @@ AMCLLaser::SetModelLikelihoodFieldProb(double z_hit,
   this->penalize_unknown = penalize_unknown;
   this->unknown_radius = unknown_radius;
   this->unknown_threshold = unknown_threshold;
+  this->unknown_min_penalty = unknown_min_penalty;
   map_update_cspace(this->map, max_occ_dist);
 }
 
@@ -255,14 +259,15 @@ double AMCLLaser::unknownPenalty(const map_t *map, pf_vector_t pose)
 {
     double in_unknown_penalty = 1.0;
 
-    double unknown_min_penalty = .2;
     if (this->penalize_unknown)
     {
         double frac_unknown = frac_unknown_area(
                 map, pose, this->unknown_radius);
         if (frac_unknown > this->unknown_threshold)
+        {
             in_unknown_penalty = fmax(
-                    1 - frac_unknown, unknown_min_penalty);
+                    1 - frac_unknown, this->unknown_min_penalty);
+        }
     }
 
     return in_unknown_penalty;

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -293,6 +293,7 @@ class AmclNode
     bool penalize_unknown_;
     int unknown_radius_;
     double unknown_threshold_;
+    double unknown_min_penalty_;
 
     void reconfigureCB(amcl::AMCLConfig &config, uint32_t level);
 
@@ -394,6 +395,7 @@ AmclNode::AmclNode() :
   private_nh_.param("penalize_unknown", penalize_unknown_, false);
   private_nh_.param("unknown_radius", unknown_radius_, 4);
   private_nh_.param("unknown_threshold", unknown_threshold_, 0.6);
+  private_nh_.param("unknown_min_penalty", unknown_min_penalty_, 0.2);
 
   private_nh_.param("do_beamskip", do_beamskip_, false);
   private_nh_.param("beam_skip_distance", beam_skip_distance_, 0.5);
@@ -615,6 +617,7 @@ void AmclNode::reconfigureCB(AMCLConfig &config, uint32_t level)
   penalize_unknown_ = config.penalize_unknown;
   unknown_radius_ = config.unknown_radius;
   unknown_threshold_ = config.unknown_threshold;
+  unknown_min_penalty_ = config.unknown_min_penalty;
 
   do_beamskip_= config.do_beamskip;
   beam_skip_distance_ = config.beam_skip_distance;
@@ -684,7 +687,8 @@ void AmclNode::initializeLaserModel()
           laser_likelihood_max_dist_,
           do_beamskip_, beam_skip_distance_,
           beam_skip_threshold_, beam_skip_error_threshold_,
-          penalize_unknown_, unknown_radius_, unknown_threshold_);
+          penalize_unknown_, unknown_radius_, unknown_threshold_,
+          unknown_min_penalty_);
     ROS_INFO("Done initializing likelihood field model with probabilities.");
   }
   else if(laser_model_type_ == LASER_MODEL_LIKELIHOOD_FIELD){
@@ -693,7 +697,8 @@ void AmclNode::initializeLaserModel()
                                     laser_likelihood_max_dist_,
                                     penalize_unknown_,
                                     unknown_radius_,
-                                    unknown_threshold_);
+                                    unknown_threshold_,
+                                    unknown_min_penalty_);
     ROS_INFO("Done initializing likelihood field model.");
   }
 }
@@ -878,7 +883,8 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
 					laser_likelihood_max_dist_,
 					do_beamskip_, beam_skip_distance_,
 					beam_skip_threshold_, beam_skip_error_threshold_,
-					penalize_unknown_, unknown_radius_, unknown_threshold_);
+					penalize_unknown_, unknown_radius_, unknown_threshold_,
+					unknown_min_penalty_);
     ROS_INFO("Done initializing likelihood field model.");
   }
   else
@@ -888,7 +894,8 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
                                     laser_likelihood_max_dist_,
                                     penalize_unknown_,
                                     unknown_radius_,
-                                    unknown_threshold_);
+                                    unknown_threshold_,
+                                    unknown_min_penalty_);
     ROS_INFO("Done initializing likelihood field model.");
   }
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -690,7 +690,10 @@ void AmclNode::initializeLaserModel()
   else if(laser_model_type_ == LASER_MODEL_LIKELIHOOD_FIELD){
     ROS_INFO("Initializing likelihood field model; this can take some time on large maps...");
     laser_->SetModelLikelihoodField(z_hit_, z_rand_, sigma_hit_,
-                                    laser_likelihood_max_dist_);
+                                    laser_likelihood_max_dist_,
+                                    penalize_unknown_,
+                                    unknown_radius_,
+                                    unknown_threshold_);
     ROS_INFO("Done initializing likelihood field model.");
   }
 }
@@ -882,7 +885,10 @@ AmclNode::handleMapMessage(const nav_msgs::OccupancyGrid& msg)
   {
     ROS_INFO("Initializing likelihood field model; this can take some time on large maps...");
     laser_->SetModelLikelihoodField(z_hit_, z_rand_, sigma_hit_,
-                                    laser_likelihood_max_dist_);
+                                    laser_likelihood_max_dist_,
+                                    penalize_unknown_,
+                                    unknown_radius_,
+                                    unknown_threshold_);
     ROS_INFO("Done initializing likelihood field model.");
   }
 


### PR DESCRIPTION
Fixes NAV-348

#### What's going on in this code? How does it fix/implement the described functionality?

Add option to penalize particles if a certain percentage of map pixels around them are unknown. The weighting scheme is linear. So if 60% of the pixels are unknown, we multiple the particle's existing weight by `.4` (or `1-.6`). This is to allow particles to somewhat travel through bits of the map with specs of unknown pixels without being penalized.

#### Changes proposed:
- penalize particles in unknown areas

#### Tested with:
- [x] Robot - kuri-00025

#### Tester should verify this with:
- [x] Robot