### PR TITLE
add auto_start param to amcl

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -355,6 +355,7 @@ AmclNode::AmclNode() :
   boost::recursive_mutex::scoped_lock l(configuration_mutex_);
 
   // Grab params off the param server
+  private_nh_.param("auto_start", should_run_, false);
   private_nh_.param("use_map_topic", use_map_topic_, false);
   private_nh_.param("first_map_only", first_map_only_, false);
 


### PR DESCRIPTION
Fixes NAV-350

#### What's going on in this code? How does it fix/implement the described functionality?

amcl uses a service to start and stop localization mode.  This lets you set it to auto-start from a rosparam.

#### Changes proposed:
- add auto_start arg to amcl.launch

#### Tested with:
- [x] Robot - kuri-0000351

#### Instructions for running:

```bash
gizmo
```

#### Tester should verify this with:
- [x] Robot - kuri-000353
